### PR TITLE
fix(files): fix deps registering twice

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,6 +60,9 @@ function flushFunc(cb) {
 }
 
 function main(arg = {}) {
+  // Fixes files being registered twice 
+  files = [];
+
   argsClosurePath = arg.closurePath;
   return through.obj(transformFunc, flushFunc);
 }


### PR DESCRIPTION
PR clears the files array in order to avoid "files registered twice" error being thrown in depgraph.